### PR TITLE
dt タグの表示を修正 (#4)

### DIFF
--- a/css/lib.css
+++ b/css/lib.css
@@ -10,11 +10,11 @@ article section div dl {
     display: grid;
     grid-template-columns: auto 1fr;
     gap: 0 1.5em;
-    align-items: center;
+    align-items: start;
 }
 
 article section div dl dt {
-    text-align-last: right;
+    text-align: right;
 }
 
 article section div dl dd {


### PR DESCRIPTION
dt タグに対応する dd タグの内容が複数行に渡る場合に、dt タグの内容が垂直中央揃えで表示されていると項目の境界がわかりづらくなる問題を修正します。

This commit fixes #4.

Before:
![image](https://github.com/moyashim-25/moyashim-25.com/assets/48670724/ee8793f5-07fd-4c31-862b-2885ff695ec2)

After:
![image](https://github.com/moyashim-25/moyashim-25.com/assets/48670724/777aafe5-9b07-4785-94f8-a6070f1b2691)
