### PR TITLE
Switch mantela.schema.json origin domain

### DIFF
--- a/.well-known/mantela.json
+++ b/.well-known/mantela.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://kusaremkn.github.io/mantela/mantela.schema.json",
+    "$schema": "https://tkytel.github.io/mantela/mantela.schema.json",
     "version": "0.0.0",
     "aboutMe": {
         "name": "moyashitel",


### PR DESCRIPTION
This PR switches the origin FQDN of mantela.schema.json to `tkytel.github.io`.